### PR TITLE
Fix kernel module alias

### DIFF
--- a/nuc_led.h
+++ b/nuc_led.h
@@ -47,7 +47,7 @@ MODULE_PARM_DESC(nuc_led_uid, "default owner of /proc/acpi/nuc_led");
 MODULE_PARM_DESC(nuc_led_gid, "default owning group of /proc/acpi/nuc_led");
 
 /* Intel NUC WMI GUID */
-#define NUCLED_WMI_MGMT_GUID "8C5DA44C-CDC3-46b3-8619-4E26D34390B7"
+#define NUCLED_WMI_MGMT_GUID "8C5DA44C-CDC3-46B3-8619-4E26D34390B7"
 MODULE_ALIAS("wmi:" NUCLED_WMI_MGMT_GUID);
 
 /* LED Control Method ID */


### PR DESCRIPTION
The GUID copied from the spec does not totally match to the WMI
interface. The kernel module will not load on boot automatically.